### PR TITLE
Remove extra 📕 from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ eleventyConfig.addPlugin(emojiReadTime, {
 Which would output:
 
 ```html
-📕📕 7 mins
+📕 7 mins
 ```
 
 ### Remove emoji from being displayed


### PR DESCRIPTION
Pretty sure based on the config example there would only be one 📕 emoji.